### PR TITLE
Initial React client and Node server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # chord-changer
-Web app that will change the displayed chord so that a guitarist can practice their chord changes
+
+Web app that will change the displayed chord so that a guitarist can practice their chord changes.
+
+## Development
+
+This repository contains a Node server and a React client. The Node server serves the compiled React application.
+
+### Setup
+
+1. Install server dependencies:
+   ```bash
+   npm install
+   ```
+2. Install client dependencies:
+   ```bash
+   npm run client-install
+   ```
+3. Build the React client:
+   ```bash
+   npm run build
+   ```
+4. Start the server:
+   ```bash
+   npm start
+   ```
+
+During development you can run the React dev server using:
+```bash
+npm run client
+```

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "client",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
+  }
+}

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Chord Changer</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function App() {
+  return (
+    <div>
+      <h1>Chord Changer</h1>
+    </div>
+  );
+}
+
+export default App;

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "chord-changer",
+  "version": "1.0.0",
+  "main": "server.js",
+  "license": "MIT",
+  "scripts": {
+    "start": "node server.js",
+    "client": "npm start --prefix client",
+    "client-install": "npm install --prefix client",
+    "build": "npm run build --prefix client"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 5000;
+
+// Serve static files from the React app
+app.use(express.static(path.join(__dirname, 'client', 'build')));
+
+// The "catchall" handler: for any request that doesn't
+// match one above, send back React's index.html file.
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'client', 'build', 'index.html'));
+});
+
+app.listen(PORT, () => console.log(`Server started on port ${PORT}`));


### PR DESCRIPTION
## Summary
- set up React client with simple welcome page
- add Express server serving React build
- document setup steps in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm test` in `client` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687506468e20832e9ded6692c6bbfe64