### PR TITLE
Add basic Vite React client and Express server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # chord-changer
-Web app that will change the displayed chord so that a guitarist can practice their chord changes
+
+This project contains a Vite React client and an Express server. The server serves the client code and integrates with Vite for hot reloading during development.
+
+## Development
+
+Run the server in development mode:
+
+```bash
+npm run dev
+```
+
+## Build
+
+Build the client for production:
+
+```bash
+npm run build
+```
+
+Start the server in production mode:
+
+```bash
+npm start
+```
+
+## Testing
+
+Tests use Jest:
+
+```bash
+npm test
+```

--- a/client/__tests__/App.test.jsx
+++ b/client/__tests__/App.test.jsx
@@ -1,0 +1,7 @@
+import { render, screen } from '@testing-library/react'
+import App from '../src/App'
+
+test('renders welcome message', () => {
+  render(<App />)
+  expect(screen.getByText(/Welcome to Chord Changer/i)).toBeInTheDocument()
+})

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chord Changer</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "chord-changer-client",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test": "jest"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.0.0",
+    "jest": "^29.0.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0",
+    "babel-jest": "^29.0.0",
+    "@babel/preset-react": "^7.0.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom",
+    "setupFilesAfterEnv": ["@testing-library/jest-dom/extend-expect"],
+    "transform": {
+      "^.+\\.jsx?$": "babel-jest"
+    }
+  },
+  "babel": {
+    "presets": ["@babel/preset-react"]
+  }
+}

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,0 +1,3 @@
+export default function App() {
+  return <h1>Welcome to Chord Changer</h1>
+}

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: 'dist'
+  }
+})

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "chord-changer",
+  "version": "1.0.0",
+  "description": "Web app that will change the displayed chord so that a guitarist can practice their chord changes",
+  "private": true,
+  "scripts": {
+    "dev": "NODE_ENV=development node server/index.js",
+    "build": "cd client && npm run build",
+    "start": "NODE_ENV=production node server/index.js",
+    "test": "jest"
+  },
+  "dependencies": {
+    "express": "^4.18.0"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0",
+    "supertest": "^6.0.0"
+  },
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/server/__tests__/server.test.js
+++ b/server/__tests__/server.test.js
@@ -1,0 +1,8 @@
+const request = require('supertest')
+const createServer = require('../index')
+
+test('serves index.html on /', async () => {
+  const app = await createServer()
+  const res = await request(app).get('/').expect(200)
+  expect(res.text).toMatch(/html/)
+})

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,32 @@
+const path = require('path');
+const express = require('express');
+
+async function createServer() {
+  const app = express();
+  const isProd = process.env.NODE_ENV === 'production';
+
+  if (!isProd) {
+    const { createServer: createViteServer } = require('vite');
+    const vite = await createViteServer({
+      server: { middlewareMode: true },
+      root: path.resolve(__dirname, '../client')
+    });
+    app.use(vite.middlewares);
+  } else {
+    const distPath = path.resolve(__dirname, '../client/dist');
+    app.use(express.static(distPath));
+    app.get('*', (_req, res) => {
+      res.sendFile(path.join(distPath, 'index.html'));
+    });
+  }
+  return app;
+}
+
+if (require.main === module) {
+  createServer().then(app => {
+    const port = process.env.PORT || 3000;
+    app.listen(port, () => console.log(`Server running on port ${port}`));
+  });
+}
+
+module.exports = createServer;


### PR DESCRIPTION
## Summary
- create Express server with Vite middleware for hot reload
- scaffold React client using Vite layout
- add Jest tests for server and client
- document dev, build, and test instructions

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68751b23a0d0832eb434e0de1c92e7ea